### PR TITLE
Enhance Accessibility of Commands

### DIFF
--- a/Christmas bot/Commands/AdminCommands.cs
+++ b/Christmas bot/Commands/AdminCommands.cs
@@ -20,18 +20,10 @@ namespace Christmas_bot.Commands
         {
             var message = await ctx.Channel.SendMessageAsync("processing...").ConfigureAwait(false);
 
-            if (!RoleHandle.IsOwner(ctx.Guild, ctx.User))
-            {
-                await MessageHandle.SendError(ctx.Channel,
-                    message: $"{ctx.User.Username} is not owner").ConfigureAwait(false);
-            }
-            else
-            {
-                RoleHandle.AddAdmin(ctx.Guild, newadmin);
+            RoleHandle.AddAdmin(ctx.Guild, newadmin);
 
-                await MessageHandle.SendSuccess(ctx.Channel,
-                    message: $"{newadmin.Username} added as admin").ConfigureAwait(false);
-            }
+            await MessageHandle.SendSuccess(ctx.Channel,
+                message: $"{newadmin.Username} added as admin").ConfigureAwait(false);
 
             await message.DeleteAsync();
         }
@@ -44,16 +36,10 @@ namespace Christmas_bot.Commands
         {
             var message = await ctx.Channel.SendMessageAsync("processing...").ConfigureAwait(false);
 
-            if (!RoleHandle.IsOwner(ctx.Guild, ctx.User))
-                await MessageHandle.SendError(ctx.Channel,
-                    message: $"{ctx.User.Username} is not owner");
-            else
-            {
-                RoleHandle.RemoveAdmin(ctx.Guild, formeradmin);
+            RoleHandle.RemoveAdmin(ctx.Guild, formeradmin);
 
-                await MessageHandle.SendSuccess(ctx.Channel,
-                    message: $"{formeradmin.Username} relegated").ConfigureAwait(false);
-            }
+            await MessageHandle.SendSuccess(ctx.Channel,
+                message: $"{formeradmin.Username} relegated").ConfigureAwait(false);
 
             await message.DeleteAsync();
         }

--- a/Christmas bot/Commands/PrefixCommands.cs
+++ b/Christmas bot/Commands/PrefixCommands.cs
@@ -20,18 +20,10 @@ namespace Christmas_bot.Commands
         {
             var message = await ctx.Channel.SendMessageAsync("processing...").ConfigureAwait(false);
 
-            if (!RoleHandle.IsAdmin(ctx.Guild, ctx.User))
-            {
-                await MessageHandle.SendError(ctx.Channel,
-                    message: $"{ctx.User.Username} is not owner").ConfigureAwait(false);
-            }
-            else
-            {
-                PrefixHandle.AddPrefix(ctx.Guild, newprefix);
+            PrefixHandle.AddPrefix(ctx.Guild, newprefix);
 
-                await MessageHandle.SendSuccess(ctx.Channel,
-                    message: $"{newprefix} added as prefix").ConfigureAwait(false);
-            }
+            await MessageHandle.SendSuccess(ctx.Channel,
+                message: $"{newprefix} added as prefix").ConfigureAwait(false);
 
             await message.DeleteAsync();
         }
@@ -44,16 +36,10 @@ namespace Christmas_bot.Commands
         {
             var message = await ctx.Channel.SendMessageAsync("processing...").ConfigureAwait(false);
 
-            if (!RoleHandle.IsAdmin(ctx.Guild, ctx.User))
-                await MessageHandle.SendError(ctx.Channel,
-                    message: $"{ctx.User.Username} is not owner");
-            else
-            {
-                PrefixHandle.RemovePrefix(ctx.Guild, formerprefix);
+            PrefixHandle.RemovePrefix(ctx.Guild, formerprefix);
 
-                await MessageHandle.SendSuccess(ctx.Channel,
-                    message: $"{formerprefix} removed").ConfigureAwait(false);
-            }
+            await MessageHandle.SendSuccess(ctx.Channel,
+                message: $"{formerprefix} removed").ConfigureAwait(false);
 
             await message.DeleteAsync();
         }


### PR DESCRIPTION
Dear Eden,

I hope this pull request finds you well. Over the past week, I could not help but notice over 61.5% of the commands listed by Christmas bot are not available to the general public. Upon delving into its source code, it is revealed that most commands check the user for admin or even owner permissions, so as to disallow the user performing various actions. I find the design of this bot discriminatory to a large extent. To address this problem, I have opened this pull request containing three commits, which will make the bot more inclusive.

It is necessary to note that most users do not possess admin or owner permissions. Without access to most commands, users can only experience a feeling of inferiority as they see an error stating they are not admin. On the Internet, it is superfluous to demonstrate privilege by only letting the bot service the nobility. As a advocate for equality, I believe equal access of Christmas bot commands can help foster a more fair and inclusive society. The removal of permission checks within the source code, which has been done in this pull request, will help achieve this effortlessly.

Hence, I ask you to click the merge pull request button to fix this problem. I assure you this pull request will not break the existing functionality of the bot, and instead make the bot more accessible to every Discord user.

I look forward to receiving an email from GitHub notifying me of my merged pull request.

Yours respectfully,
Jono